### PR TITLE
Add bidirectional broteñol translator

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,71 +1,131 @@
-const loveWords = ["love", "amo", "愛", "愛してる"];
-const thanksWords = ["thanks", "thank you", "gracias", "ありがとう"];
-const cheeseWords = ["cheese", "queso", "チーズ"];
-const helloWords = ["hello", "hola", "こんにちは"];
+// Traductor bidireccional Español/Broteñol
 
-function traducirNormal(text) {
-  text = text.toLowerCase();
+const alphabet = {
+  a: "mi",
+  b: "mimi",
+  c: "mii",
+  d: "mei",
+  e: "ni",
+  f: "mu",
+  g: "pi",
+  h: "miji",
+  i: "mu",
+  j: "mei",
+  k: "miu",
+  l: "mimi",
+  m: "mii",
+  n: "ni",
+  o: "mu",
+  p: "pi",
+  q: "ku",
+  r: "ru",
+  s: "si",
+  t: "ti",
+  u: "mu",
+  v: "vivi",
+  w: "wu",
+  x: "xixi",
+  y: "yii",
+  z: "zizi"
+};
 
-  if (loveWords.some(word => text.includes(word))) {
-    return "mi-mi mi";
+const reservedWords = {
+  "mi": "yo / amor",
+  "mi-mi": "tú",
+  "mii": "muy / mucho",
+  "mimi": "pequeño / lindo",
+  "mei": "Meica",
+  "mei-mi": "Meica",
+  "mei-mimi": "Meica",
+  "miu pi": "queso",
+  "mimi-mi": "súper ternura",
+  "nini": "tristeza",
+  "miji": "juego",
+  "ti": "acción",
+  "xixi": "secreto",
+  "kiki": "emoción intensa",
+  "ru": "advertencia",
+  "wu": "risa",
+  "vivi": "energía alegre",
+  "mñi": "timidez"
+};
+
+const inverseAlphabet = {};
+for (const [letter, brote] of Object.entries(alphabet)) {
+  if (!inverseAlphabet[brote]) {
+    inverseAlphabet[brote] = letter;
   }
-  if (thanksWords.some(word => text.includes(word))) {
-    return "mimi-mi mu";
-  }
-  if (cheeseWords.some(word => text.includes(word))) {
-    return "miu pi";
-  }
-  if (helloWords.some(word => text.includes(word))) {
-    return "mu mimi";
-  }
-  return "\uD83C\uDF31 (miu? no entiendo eso)";
 }
 
-function traducirInverso(brote) {
-  let desglose = "";
-  let traduccion = "";
+function containsBrote(text) {
+  const lower = text.toLowerCase();
+  return Object.keys(reservedWords).some(w => lower.includes(w));
+}
 
-  if (brote.includes("mi-mi")) {
-    desglose += "- mi-mi = tú\n";
-    traduccion += "te ";
-  }
-  if (brote.includes("mi")) {
-    desglose += "- mi = amo / amor\n";
-    traduccion += "amo ";
-  }
-  if (brote.includes("mei-mi")) {
-    desglose += "- mei-mi = Meica\n";
-    traduccion += "Meica ";
-  }
-  if (brote.includes("ni")) {
-    desglose += "- ni = cariño peque\n";
-    traduccion += "(peque) ";
-  }
-  if (brote.includes("mimi-mi")) {
-    desglose += "- mimi-mi = gracias\n";
-    traduccion += "gracias ";
-  }
-  if (brote.includes("miu pi")) {
-    desglose += "- miu pi = queso\n";
-    traduccion += "queso ";
-  }
-  if (brote.includes("mu mimi")) {
-    desglose += "- mu mimi = hola\n";
-    traduccion += "hola ";
+function toBrote(text) {
+  const lower = text.toLowerCase();
+  let translation = "";
+  const breakdown = [];
+
+  for (const ch of lower) {
+    if (alphabet[ch]) {
+      if (translation && !translation.endsWith(" ")) translation += " ";
+      translation += alphabet[ch];
+      breakdown.push(`${ch}→${alphabet[ch]}`);
+    } else {
+      translation += ch;
+      if (ch.trim()) {
+        breakdown.push(`${ch}→${ch}`);
+      }
+    }
   }
 
-  return `Traducción: ${traduccion.trim()}\n\n\uD83C\uDF31 Desglose broteñol:\n${desglose.trim()}`;
+  return { text: translation.trim(), breakdown: breakdown.join(", ") };
+}
+
+function fromBrote(text) {
+  const words = text.toLowerCase().trim().split(/\s+/);
+  let i = 0;
+  let translation = "";
+  const breakdown = [];
+
+  while (i < words.length) {
+    const current = words[i];
+    const next = words[i + 1];
+
+    if (next && reservedWords[`${current} ${next}`]) {
+      const key = `${current} ${next}`;
+      translation += reservedWords[key] + " ";
+      breakdown.push(`${key}→${reservedWords[key]}`);
+      i += 2;
+      continue;
+    }
+
+    if (reservedWords[current]) {
+      translation += reservedWords[current] + " ";
+      breakdown.push(`${current}→${reservedWords[current]}`);
+    } else if (inverseAlphabet[current]) {
+      translation += inverseAlphabet[current];
+      breakdown.push(`${current}→${inverseAlphabet[current]}`);
+    } else {
+      translation += current;
+      breakdown.push(`${current}→${current}`);
+    }
+    i += 1;
+  }
+
+  return { text: translation.trim(), breakdown: breakdown.join(", ") };
 }
 
 function traducir() {
   const input = document.getElementById("inputText").value.trim();
-  let output = "";
-
-  if (/mi|mii|mimi|mei|ni|mu|miu/.test(input)) {
-    output = traducirInverso(input.toLowerCase());
-  } else {
-    output = traducirNormal(input);
+  if (!input) {
+    document.getElementById("outputText").innerText = "";
+    return;
   }
 
+  const isBrote = containsBrote(input);
+  const result = isBrote ? fromBrote(input) : toBrote(input);
+  const output = `Traducción: ${result.text}\n\n🌱 Desglose:\n${result.breakdown}`;
   document.getElementById("outputText").innerText = output;
 }


### PR DESCRIPTION
## Summary
- implement a full bidirectional translator in `script.js`
- map alphabet letters to broteñol tokens
- recognise reserved broteñol words for inverse translation
- show translation breakdown for either direction

## Testing
- `node --check script.js`
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('./script.js','utf8');
const outputElem={innerText:''};
const context={document:{getElementById:id=>id==='inputText'?{value:'hola'}:outputElem}};
vm.createContext(context);vm.runInContext(code,context);context.traducir();console.log(outputElem.innerText);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_686860f448fc832992ead511b26330d7