### PR TITLE
Improve reserved word handling in broteñol translator

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,19 +98,22 @@ function toBrote(text) {
   const breakdown = [];
   for (const original of words) {
     const lower = original.toLowerCase();
-    if (dictionary[lower]) {
+    if (lower === "meica") {
+      result.push("mei");
+      breakdown.push("meica → mei");
+    } else if (reservedNames.includes(lower) || /^[A-ZÁÉÍÓÚÑ]/.test(original)) {
+      result.push("mei");
+      breakdown.push(`${original} → mei`);
+    } else if (dictionary[lower]) {
       result.push(dictionary[lower]);
       breakdown.push(`${original} → ${dictionary[lower]}`);
     } else if (lower === "diego") {
       result.push("mie");
       breakdown.push(`${original} → mie`);
-    } else if (reservedNames.includes(lower) || /^[A-ZÁÉÍÓÚÑ]/.test(original)) {
-      result.push("mei");
-      breakdown.push(`${original} → mei`);
     } else {
       const byLetters = wordToBroteByLetters(original);
       result.push(byLetters.text);
-      breakdown.push(`${original} → ${byLetters.detail.join(" ")}`);
+      breakdown.push(`${original} → ${byLetters.breakdown.join(" ")}`);
     }
   }
   return { text: result.join(" "), breakdown: breakdown.join("\n") };
@@ -153,7 +156,7 @@ function fromBrote(text) {
     } else {
       const byLetters = broteWordToLetters(current);
       result.push(byLetters.text);
-      breakdown.push(`${current} → ${byLetters.detail.join(" ")}`);
+      breakdown.push(`${current} → ${byLetters.breakdown.join(" ")}`);
     }
     i += 1;
   }


### PR DESCRIPTION
## Summary
- ensure reserved names like `meica` and capitalized words translate to `mei`
- fix breakdown output when translating letter-by-letter
- correct reverse translation breakdown logic

## Testing
- `node -e "const fs=require('fs');eval(fs.readFileSync('script.js','utf8'));console.log(toBrote('hola meica queso'));"`
- `node -e "const fs=require('fs');eval(fs.readFileSync('script.js','utf8'));console.log(fromBrote('mi-mi mei miu pi'));"`


------
https://chatgpt.com/codex/tasks/task_e_686870610f4c8329b90d4ba10f04782f