### PR TITLE
Fix `meica` translation breakdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -100,7 +100,7 @@ function toBrote(text) {
     const lower = original.toLowerCase();
     if (lower === "meica") {
       result.push("mei");
-      breakdown.push("meica → mei");
+      breakdown.push("- meica → mei");
     } else if (reservedNames.includes(lower) || /^[A-ZÁÉÍÓÚÑ]/.test(original)) {
       result.push("mei");
       breakdown.push(`${original} → mei`);


### PR DESCRIPTION
## Summary
- always translate `meica`/`Meica` as `mei`
- show fixed breakdown entry `- meica → mei`

## Testing
- `node - <<'NODE'
const vm=require('vm');
const fs=require('fs');
const code=fs.readFileSync('script.js','utf8');
const context={};
vm.createContext(context);
vm.runInContext(code, context);
const r=context.toBrote('Meica brote');
console.log(r);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68687c8dd6f083299ccd6a5ba12ff81a