### PR TITLE
Fix Broteñol meica rule

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,8 +15,6 @@ const dictionary = {
   "meica": "mei"
 };
 
-// Lista de nombres reservados
-const reservedNames = ["meica", "luis"];
 
 // Palabras broteñolas reservadas para traducción inversa
 const broteReserved = {
@@ -101,9 +99,6 @@ function toBrote(text) {
     if (lower === "meica") {
       result.push("mei");
       breakdown.push("- meica → mei");
-    } else if (reservedNames.includes(lower) || /^[A-ZÁÉÍÓÚÑ]/.test(original)) {
-      result.push("mei");
-      breakdown.push(`${original} → mei`);
     } else if (dictionary[lower]) {
       result.push(dictionary[lower]);
       breakdown.push(`${original} → ${dictionary[lower]}`);


### PR DESCRIPTION
## Summary
- remove default name/uppercase conversion to "mei"
- keep dedicated conversion for `meica`

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68687ec625a083298b39ccea1abe86f5