### PR TITLE
Fix inverse Broteñol translation for "mei"

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,7 +21,7 @@ const broteReserved = {
   "mi-mi": "hola",
   "mimi": "lindo",
   "miu pi": "queso",
-  "mei": "Meica",
+  "mei": "meica",
   "mimi-mi": "súper ternura",
   "xixi": "secreto",
   "miji": "juego",


### PR DESCRIPTION
## Summary
- correct brote → normal mapping of `mei` so it returns `meica`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68688102a04483298251e1351e615668