### PR TITLE
Improve letter breakdown layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -108,7 +108,7 @@ function toBrote(text) {
     } else {
       const byLetters = wordToBroteByLetters(original);
       result.push(byLetters.text);
-      breakdown.push(`${original} → ${byLetters.breakdown.join(" ")}`);
+      breakdown.push(`${original}:\n  ${byLetters.breakdown.join("\n  ")}`);
     }
   }
   return { text: result.join(" "), breakdown: breakdown.join("\n") };
@@ -151,7 +151,7 @@ function fromBrote(text) {
     } else {
       const byLetters = broteWordToLetters(current);
       result.push(byLetters.text);
-      breakdown.push(`${current} → ${byLetters.breakdown.join(" ")}`);
+      breakdown.push(`${current}:\n  ${byLetters.breakdown.join("\n  ")}`);
     }
     i += 1;
   }


### PR DESCRIPTION
## Summary
- show per-letter breakdown vertically in translations

## Testing
- `node -e "const vm=require('vm'),fs=require('fs');vm.runInThisContext(fs.readFileSync('script.js','utf8'));console.log(toBrote('meuca').breakdown);"`

------
https://chatgpt.com/codex/tasks/task_e_686882327cc483299b8512e99c4f494b