### PR TITLE
Improve vertical breakdown formatting

### DIFF
--- a/script.js
+++ b/script.js
@@ -108,7 +108,9 @@ function toBrote(text) {
     } else {
       const byLetters = wordToBroteByLetters(original);
       result.push(byLetters.text);
-      breakdown.push(`${original}:\n  ${byLetters.breakdown.join("\n  ")}`);
+      breakdown.push(
+        `${original}:\n${byLetters.breakdown.map((d) => "  " + d).join("\n")}`
+      );
     }
   }
   return { text: result.join(" "), breakdown: breakdown.join("\n") };
@@ -151,7 +153,9 @@ function fromBrote(text) {
     } else {
       const byLetters = broteWordToLetters(current);
       result.push(byLetters.text);
-      breakdown.push(`${current}:\n  ${byLetters.breakdown.join("\n  ")}`);
+      breakdown.push(
+        `${current}:\n${byLetters.breakdown.map((d) => "  " + d).join("\n")}`
+      );
     }
     i += 1;
   }


### PR DESCRIPTION
## Summary
- reformat `toBrote` and `fromBrote` breakdown logic
- ensure each letter breakdown appears indented on its own line

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_6868841e2f8c8329b541b151dd8c97c9