### PR TITLE
Add brotenol reserved words

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,7 +9,9 @@ const esToBrRaw = {
   "mirar":"yii ti", "hablar":"miji ni", "dormir":"mu mu", "comer":"pi pi",
   "beber":"mu pi", "cansado":"mu nini", "emocionado":"kiki vivi",
   "sorprendido":"yii wu", "hoy":"mi-mi ti", "mañana":"mii ni", "ayer":"ru ni",
-  "siempre":"wu wu", "nunca":"nini nini"
+  "siempre":"wu wu", "nunca":"nini nini", "culona":"muku", "pene":"mupi",
+  "muslo":"miwu", "tetona":"misi", "hermosa":"miyi", "princesa":"muki",
+  "pinchechota":"muzi"
 };
 
 const brToEs = {
@@ -54,6 +56,13 @@ const brToEs = {
   "ru ni": "ayer",
   "wu wu": "siempre",
   "nini nini": "nunca",
+  "muku": "culona",
+  "mupi": "pene",
+  "miwu": "muslo",
+  "misi": "tetona",
+  "miyi": "hermosa",
+  "muki": "princesa",
+  "muzi": "pinchechota",
 };
 
 const esAlphabet = {


### PR DESCRIPTION
## Summary
- add 'culona', 'pene', 'muslo', 'tetona', 'hermosa', 'princesa' and 'pinchechota' to the Spanish→Broteñol dictionary
- add the matching Broteñol→Spanish reverse mappings

## Testing
- `node -e "global.window={addEventListener:()=>{}};const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('script.js','utf8');vm.runInThisContext(code);console.log('toBr', translateEsToBr('culona pene muslo tetona hermosa princesa pinchechota').text);"`

------
https://chatgpt.com/codex/tasks/task_e_6868b45a61e083299b3d61353ec87a4b