### PR TITLE
Fix inverse translation logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,21 +112,28 @@ function translateBrToEs(text) {
   const tokens = text.trim().toLowerCase().split(/\s+/).filter(Boolean);
   if (!tokens.length) return { text: '', breakdown: '' };
 
-  let result = '';
+  const words = [];
+  let letterBuffer = '';
   const detail = [];
-  tokens.forEach((t, i) => {
+
+  tokens.forEach(t => {
     if (brToEs[t]) {
-      result += brToEs[t];
-      if (i < tokens.length - 1) result += ' ';
+      if (letterBuffer) {
+        words.push(letterBuffer);
+        letterBuffer = '';
+      }
+      words.push(brToEs[t]);
       detail.push(`${t}→${brToEs[t]}`);
     } else {
       const ch = brAlphabet[t] || '';
-      result += ch;
+      letterBuffer += ch;
       detail.push(`${t}→${ch}`);
     }
   });
 
-  return { text: result, breakdown: detail.join(' | ') + ' |' };
+  if (letterBuffer) words.push(letterBuffer);
+
+  return { text: words.join(' '), breakdown: detail.join(' | ') + ' |' };
 }
 
 function clearResult() {


### PR DESCRIPTION
## Summary
- adjust broteñol→español translation to collect letter tokens until a dictionary match
- flush buffered letters as words when a dictionary word is found
- keep breakdown display the same

## Testing
- `node -e "global.window={addEventListener:()=>{}}; global.document={}; const fs=require('fs'); eval(fs.readFileSync('script.js','utf8')); console.log(translateBrToEs('mi--mi muku ni ru ni si miyi'));"`

------
https://chatgpt.com/codex/tasks/task_e_6868b86d62608329ba3605c445769355