### PR TITLE
Fix breakdown for quoted reverse translation

### DIFF
--- a/script.js
+++ b/script.js
@@ -129,10 +129,11 @@ function translateBrToEs(text) {
       const parts = inside.split(/\s+/).filter(Boolean);
       let letters = '';
       parts.forEach(p => {
-        letters += brAlphabet[p] || parseBrWord(p);
+        const letter = brAlphabet[p] || parseBrWord(p);
+        letters += letter;
+        detail.push(`${p}→${letter}`);
       });
       words.push(letters);
-      detail.push(`${t}→${letters}`);
     } else if (brToEs[t]) {
       words.push(brToEs[t]);
       detail.push(`${t}→${brToEs[t]}`);


### PR DESCRIPTION
## Summary
- improve the handling of broteñol text inside double quotes
- show each syllable mapping when translating from broteñol to Spanish

## Testing
- `node - <<'NODE'
const fs=require('fs'); let code=fs.readFileSync('script.js','utf8'); code=code.split('\nwindow.addEventListener')[0]; const wrapper=`(function(){${code}; return {translateBrToEs, translateEsToBr};})();`; const t=eval(wrapper); console.log(t.translateEsToBr('jugamos')); console.log(t.translateBrToEs('"mei mu pii mi mii mu si"'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6868d0748f3c832993772bce96d8948e