### PR TITLE
Fix sensei/maestro mapping

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ const esToBr = {
   "musica":"musi", "baile":"bai", "fiesta":"fesi", "hermosa":"miyi",
   "princesa":"muki", "pene":"mupi", "muslo":"miwu", "tetona":"misi",
   "pinchechota":"muzi", "miy":"te", "meica":"mei", "te":"miy", "xd":"xidii",
-  "diego":"mie", "sensei":"miisei", "maestro":"miisei"
+  "diego":"mie", "sensei":"miisei", "maestro":"maisei"
 
 };
 
@@ -53,7 +53,7 @@ const brToEs = {
   "sili":"silla", "miji":"juego", "musi":"musica", "bai":"baile",
   "fesi":"fiesta", "miyi":"hermosa", "muki":"princesa", "mupi":"pene",
   "miwu":"muslo", "misi":"tetona", "muzi":"pinchechota", "miy":"te",  
-  "miisei":"maestro", "mei":"meica", "mie":"diego", "xidii":"xd", "miisei":"sensei"
+  "maisei":"maestro", "mei":"meica", "mie":"diego", "xidii":"xd", "miisei":"sensei"
  
 };
 


### PR DESCRIPTION
## Summary
- correct the Broteñol dictionary entry for `maestro`
- ensure the reverse dictionary maps the new token back to `maestro`

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_686a0029a10c8329b52634ab8717af98